### PR TITLE
Fix header guard issues and add Bluetooth globals

### DIFF
--- a/Bluetooth.cpp
+++ b/Bluetooth.cpp
@@ -1,0 +1,11 @@
+#include "Bluetooth.h"
+
+#if MCU_VARIANT == MCU_NRF52
+bool SerialBT_init = false;
+#endif
+
+uint32_t bt_pairing_started = 0;
+uint8_t dev_bt_mac[BT_DEV_ADDR_LEN];
+char bt_da[BT_DEV_ADDR_LEN];
+char bt_dh[BT_DEV_HASH_LEN];
+char bt_devname[11];

--- a/Bluetooth.h
+++ b/Bluetooth.h
@@ -10,6 +10,8 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
+#pragma once
+
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -33,19 +35,19 @@
   BLEUart SerialBT(BLE_RX_BUF);
   BLEDis  bledis;
   BLEBas  blebas;
-  bool SerialBT_init = false;
+  extern bool SerialBT_init;
 #endif
 
 #define BT_PAIRING_TIMEOUT 35000
 #define BLE_FLUSH_TIMEOUT 20
-uint32_t bt_pairing_started = 0;
+extern uint32_t bt_pairing_started;
 
 #define BT_DEV_ADDR_LEN 6
 #define BT_DEV_HASH_LEN 16
-uint8_t dev_bt_mac[BT_DEV_ADDR_LEN];
-char bt_da[BT_DEV_ADDR_LEN];
-char bt_dh[BT_DEV_HASH_LEN];
-char bt_devname[11];
+extern uint8_t dev_bt_mac[BT_DEV_ADDR_LEN];
+extern char bt_da[BT_DEV_ADDR_LEN];
+extern char bt_dh[BT_DEV_HASH_LEN];
+extern char bt_devname[11];
 
 #if MCU_VARIANT == MCU_ESP32
   #if HAS_BLUETOOTH == true

--- a/Display.h
+++ b/Display.h
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#pragma once
+
 #include <Adafruit_GFX.h>
 
 #define DISP_W 128
@@ -1070,7 +1072,11 @@ void update_disp_area() {
 void display_recondition() {
   #if DISPLAY == OLED
     for (uint8_t iy = 0; iy < disp_area.height(); iy++) {
-      unsigned char rand_seg [] = {random(0xFF),random(0xFF),random(0xFF),random(0xFF),random(0xFF),random(0xFF),random(0xFF),random(0xFF)};
+      uint8_t rand_seg[] = {
+        static_cast<uint8_t>(random(256)), static_cast<uint8_t>(random(256)),
+        static_cast<uint8_t>(random(256)), static_cast<uint8_t>(random(256)),
+        static_cast<uint8_t>(random(256)), static_cast<uint8_t>(random(256)),
+        static_cast<uint8_t>(random(256)), static_cast<uint8_t>(random(256))};
       stat_area.drawBitmap(0, iy, rand_seg, 64, 1, DISPLAY_WHITE, DISPLAY_BLACK);
       disp_area.drawBitmap(0, iy, rand_seg, 64, 1, DISPLAY_WHITE, DISPLAY_BLACK);
     }


### PR DESCRIPTION
## Summary
- add `#pragma once` to `Display.h` and `Bluetooth.h`
- make Bluetooth global variables extern in the header
- move the Bluetooth global definitions into new `Bluetooth.cpp`
- fix narrowing warnings in `display_recondition` by casting `random()` values

## Testing
- `make` *(fails: `../../sites/reticulum.network: No such file or directory`)*
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686249a73f088324a36de7f73f37778f