### PR TITLE
Fix missing Arduino include in Bluetooth header

### DIFF
--- a/Bluetooth.h
+++ b/Bluetooth.h
@@ -11,6 +11,7 @@
 // GNU General Public License for more details.
 
 #pragma once
+#include <Arduino.h>
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
## Summary
- include `<Arduino.h>` in `Bluetooth.h` so types like `uint32_t` are defined

## Testing
- `make firmware-rak4631` *(fails: `arduino-cli` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e40794d88324a8f0b9e03b09592c